### PR TITLE
Update objtools to version 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "md5": "^2.2.1",
-    "objtools": "^1.6.5"
+    "objtools": "^4.0.0"
   },
   "devDependencies": {
     "browserify": "^16.1.0"


### PR DESCRIPTION
This updates `objtools` from 1.6.5 to 4.0.0.

`objtools.deepCopy` is the only thing used (as far as I can tell), which I don't think had breaking changes between these versions.